### PR TITLE
Fix Hanalon classes which stopped working after d.py 1.7.0

### DIFF
--- a/src/cogs/diagnostics.py
+++ b/src/cogs/diagnostics.py
@@ -6,13 +6,13 @@ from discord.ext import commands
 from utils.bot import bot, include_cog
 from utils.responses import HanalonEmbed, HanalonResponse
 
-# from .rpg.db import Character, Party, Clan
+from .rpg.db import Character, Clan, Party
 
 
 class Diagnostics(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        # self.coolio = []
+        self.coolio = []
 
     @commands.command(aliases=("harakiri",))
     @bot.owner_only
@@ -22,7 +22,7 @@ class Diagnostics(commands.Cog):
         """
         await HanalonEmbed(title="さよなら〜", context=ctx).respond(True, override=True)
         await self.bot.change_presence(status=discord.Status.invisible)
-        await self.bot.logout()
+        await self.bot.close()
 
     @commands.command()
     async def echo(self, ctx: commands.Context, *, msg: str):
@@ -40,7 +40,6 @@ class Diagnostics(commands.Cog):
         await HanalonEmbed(title=msg, context=ctx).respond(True, destination=channel)
 
     # @commands.command()
-    # @bot.owner_only
     # async def test(self, ctx: commands.Context):
     #     if self.coolio == []:
     #         await bot.characters.delete_many(dict())

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -85,10 +85,10 @@ class HanalonEmbed(discord.Embed):
     def __init__(
         self,
         context: Context,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
+        title: str = "",
+        description: str = "",
         color: Union[discord.Color, int] = bot.color,
-        url: Optional[str] = None,
+        url: str = "",
     ):
         super().__init__(title=title, description=description, color=color, url=url)
         if isinstance(context, slash.Context):
@@ -178,7 +178,10 @@ class HanalonResponse:
             if args or kwargs:
                 kwargs["mention_author"] = False
                 try:
-                    if isinstance(self.destination, discord.abc.Messageable):
+                    if (
+                        isinstance(self.destination, discord.abc.Messageable)
+                        and self.destination != self.context.channel
+                    ):
                         await self.destination.send(*args, **kwargs)
                     else:
                         await self.context.reply(*args, **kwargs)


### PR DESCRIPTION
Hanalon classes originally pass in None, but now that discord.py converts it to a string, we must pass in "" instead.